### PR TITLE
feat: added custom icon prop to panels

### DIFF
--- a/44frontend/src/components/Panel/index.tsx
+++ b/44frontend/src/components/Panel/index.tsx
@@ -12,16 +12,18 @@ interface IPanelBase {
 type IPanelConditional = {
     action: "link";
     url: string
+    icon?: string;
     setIsOpen?: never;
 } | {
     action: "button";
+    icon?: never;
     setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
     url?: never
 }
 
 type IPanel = IPanelBase & IPanelConditional
 
-export default function Panel({ text, last = false, flipped = false, noInfo = false, action = "link", url, setIsOpen }: IPanel) {
+export default function Panel({ text, last = false, flipped = false, noInfo = false, icon = arrow, action = "link", url, setIsOpen }: IPanel) {
     if (action === "link" && url) { // panel acts as a link
         return (
             <Link to={url} className={`${styles.container} ${last ? styles.last__panel : ""} ${flipped ? styles.flipped : ""}`}>
@@ -33,7 +35,7 @@ export default function Panel({ text, last = false, flipped = false, noInfo = fa
                             Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque ad ex deleniti ratione a nam tempore dolorem tempora rem voluptatum!
                         </div>) :
                         (<div className={styles.arrow__container}>
-                            <img src={arrow} alt="arrow icon" className={flipped ? styles.image__flipped : ""} />
+                            <img src={icon} alt="arrow icon" className={flipped ? styles.image__flipped : ""} />
                         </div>)
                     }
 


### PR DESCRIPTION
This PR adds a custom Icon prop to the panels component allowing you to pass in a string to control what icon displays on a panel when "action" is set to "link"