### PR TITLE
Bac feat/schema

### DIFF
--- a/44sanity/schemas/feed.ts
+++ b/44sanity/schemas/feed.ts
@@ -1,0 +1,31 @@
+export default {
+    name: 'feed',
+    type: 'document',
+    title: 'Article',
+    fields: [
+        {
+            name: 'publicationName',
+            type: 'string',
+            title: 'Publication Name',
+            description: "The name of the Editorial that wrote the post. e.g. More Branches, Fader"
+        },
+        {
+            name: 'title',
+            type: 'string',
+            title: 'Title',
+            description: 'The title of the article'
+        },
+        {
+            name: 'logo',
+            type: 'image',
+            title: 'Company Logo',
+            description: 'The logo for the Editorial'
+        },
+        {
+            name: 'link',
+            type: 'url',
+            title: 'Article Link',
+            description: 'A valid link to the Article'
+        }
+    ]
+}

--- a/44sanity/schemas/index.ts
+++ b/44sanity/schemas/index.ts
@@ -1,3 +1,5 @@
 import talent from "./talent"
+import feed from "./feed"
+import work from "./work"
 
-export const schemaTypes = [talent]
+export const schemaTypes = [talent, feed, work]

--- a/44sanity/schemas/talent.ts
+++ b/44sanity/schemas/talent.ts
@@ -6,17 +6,20 @@ export default {
         {
             name: 'name',
             type: 'string',
-            title: 'Name'
+            title: 'Name',
+            validation: (Rule: any) => Rule.required()
         },
         {
             name: 'shortBio',
             type: 'string',
-            title: 'Short Bio'
+            title: 'Short Bio',
+            validation: (Rule: any) => Rule.required().min(20).max(250)
         },
         {
             name: 'profileImage',
             type: 'image',
-            title: 'Profile Image'
+            title: 'Profile Image',
+            validation: (Rule: any) => Rule.required()
         }
     ]
 }

--- a/44sanity/schemas/work.ts
+++ b/44sanity/schemas/work.ts
@@ -7,20 +7,23 @@ export default {
             name: 'title',
             type: 'string',
             title: 'Title',
-            description: 'Title of this work'
+            description: 'Title of this work',
+            validation: (Rule: any) => Rule.required()
         },
         {
             name: 'contributor',
-            type: 'reference',
+            type: 'array',
             title: 'Contributor',
-            to: [{ type: 'talent' }],
-            description: 'Name of the contributor in 44 that was involved in this work'
+            of: [{ type: 'reference', to: [{ type: 'talent' }] }],
+            description: 'Name of the contributor in 44 that was involved in this work',
+            validation: (Rule: any) => Rule.required()
         },
         {
             name: 'artistName',
             type: 'string',
             title: 'Artist Name',
-            description: 'Name of the artist on the song/instrumental as seen on streaming services'
+            description: 'Name of the artist on the song/instrumental as seen on streaming services',
+            validation: (Rule: any) => Rule.required()
         },
         {
             name: 'features',
@@ -33,7 +36,8 @@ export default {
             name: 'cover',
             type: 'image',
             title: 'Cover Art',
-            desctription: 'Cover Art for this work'
+            desctription: 'Cover Art for this work',
+            validation: (Rule: any) => Rule.required()
         }
     ]
 }

--- a/44sanity/schemas/work.ts
+++ b/44sanity/schemas/work.ts
@@ -1,0 +1,39 @@
+export default {
+    name: 'work',
+    type: 'document',
+    title: 'Work',
+    fields: [
+        {
+            name: 'title',
+            type: 'string',
+            title: 'Title',
+            description: 'Title of this work'
+        },
+        {
+            name: 'contributor',
+            type: 'reference',
+            title: 'Contributor',
+            to: [{ type: 'talent' }],
+            description: 'Name of the contributor in 44 that was involved in this work'
+        },
+        {
+            name: 'artistName',
+            type: 'string',
+            title: 'Artist Name',
+            description: 'Name of the artist on the song/instrumental as seen on streaming services'
+        },
+        {
+            name: 'features',
+            type: 'array',
+            of: [{ type: 'string' }],
+            title: 'Features',
+            description: 'A list of features that were on the song/project'
+        },
+        {
+            name: 'cover',
+            type: 'image',
+            title: 'Cover Art',
+            desctription: 'Cover Art for this work'
+        }
+    ]
+}


### PR DESCRIPTION
This PR implements new schema and validation for the sanity backend and adds validation to the already existing talent schema.
New Schema includes:

- Work
- Feed

There is now also a 250 character limit for the short bio field in the talent schema